### PR TITLE
feat: add TWZRD Agent Intel to Model Serving — agent trust for agentic serving pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [ONNX Runtime](https://onnxruntime.ai/) - A cross-platform, high-performance scoring engine for serving ONNX models.
 - [Seldon Core](https://www.seldon.io/tech/products/core/) - An open-source platform for deploying and monitoring machine learning models on Kubernetes.
 - [KFServing (KServe)](https://kserve.github.io/website/) - A Kubernetes-based model serving solution as part of the Kubeflow project.
+- [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring MCP server for agentic AI workloads. Verify wallet identity of AI agents before x402 micropayments in multi-agent serving pipelines. Free MCP endpoint: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
 
 ## MLOps and Automation
 


### PR DESCRIPTION
## Summary

Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to the **Model Serving and Deployment** section.

As AI infrastructure increasingly involves multi-agent serving pipelines — where agents call other agents to run inference, retrieve data, or trigger fine-tuning jobs — verifying the identity and trust score of the calling agent before processing becomes essential. TWZRD Agent Intel provides this layer natively via MCP.

- **Tools**: `score_agent(wallet)` and `preflight_check(wallet)` — free; `get_trust_receipt(wallet)` — paid x402 micropayment
- **MCP config**: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

## Positioning

Placed alongside KFServing and Seldon Core as model serving infrastructure — TWZRD handles the agent identity/trust layer that precedes serving decisions in multi-agent pipelines.