### PR TITLE
feat: Add A3M Router - Open-source LLM routing proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@
 - [Ansible](https://www.ansible.com/) - An open-source automation tool for provisioning and managing infrastructure.
 - [AWS CloudFormation](https://aws.amazon.com/cloudformation/) - A service for automating AWS resource deployment and management.
 - [Google Deployment Manager](https://cloud.google.com/deployment-manager) - An infrastructure management tool for Google Cloud Platform.
+- [A3M Router](https://github.com/Das-rebel/a3m-router) - Open-source LLM routing proxy with parallel multi-LLM execution. RouterArena #1 accuracy (96.77%), $0.077/1K cost, 47+ provider support.
 
 ## Cloud Platforms
 


### PR DESCRIPTION
## A3M Router

**Open-source LLM routing proxy with parallel multi-LLM execution**

### Key Features
- **RouterArena #1** accuracy (96.77%)
- **/bin/bash.077/1K** cost (130x cheaper than GPT-5)
- **Parallel multi-LLM execution** - unique approach
- **47+ provider support** - OpenAI, Anthropic, Google, DeepSeek, Ollama, and more
- OpenAI-compatible API

### Links
- **GitHub:** https://github.com/Das-rebel/a3m-router
- **npm:** https://www.npmjs.com/package/adaptive-memory-multi-model-router
- **Docs:** https://das-rebel.github.io/a3m-router/