### PR TITLE
Add Doubleword Control Layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [ONNX Runtime](https://onnxruntime.ai/) - A cross-platform, high-performance scoring engine for serving ONNX models.
 - [Seldon Core](https://www.seldon.io/tech/products/core/) - An open-source platform for deploying and monitoring machine learning models on Kubernetes.
 - [KFServing (KServe)](https://kserve.github.io/website/) - A Kubernetes-based model serving solution as part of the Kubeflow project.
+- [Doubleword Control Layer](https://github.com/doublewordai/control-layer) - A high-performance AI model gateway that unifies access to LLMs across providers behind a single authentication layer, with API key generation, user management, and request logging.
 
 ## MLOps and Automation
 


### PR DESCRIPTION
### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows our quality and content standards.
- [x] I have not added a link to my own project if it's not notable or widely used.

### Description of the Change

Adds the Doubleword Control Layer to the **Model Serving and Deployment** section. It is an open-source, high-performance AI model gateway (written in Rust) that provides unified access to LLMs across providers behind a single authentication layer, with API key generation, user management, and request logging. It sits alongside existing serving/gateway entries such as KFServing (KServe), Seldon Core, and NVIDIA Triton, filling the gap for a lightweight inference gateway / control plane.

Entry follows the existing `- [Name](url) - Description.` format and passes the repository's awesome-list lint for the added line.

### Additional Notes (if any)

Single entry, appended to the end of the Model Serving and Deployment section. No existing links were modified or duplicated.